### PR TITLE
Add timestamp writer support

### DIFF
--- a/treewriterfactory.go
+++ b/treewriterfactory.go
@@ -78,6 +78,11 @@ func createTreeWriter(codec CompressionCodec, schema *TypeDescription, writers w
 		if err != nil {
 			return nil, err
 		}
+	case CategoryTimestamp:
+		treeWriter, err = NewTimestampTreeWriter(category, codec)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("unsupported type: %s", category)
 	}

--- a/utils.go
+++ b/utils.go
@@ -1202,3 +1202,19 @@ func zigzagEncode(i int64) uint64 {
 func zigzagDecode(i uint64) int64 {
 	return int64((i >> 1) ^ uint64((int64(i&1)<<63)>>63))
 }
+
+func formatNanos(nanos int64) int64 {
+	if nanos == 0 {
+		return 0
+	} else if nanos%100 != 0 {
+		return nanos << 3
+	} else {
+		nanos /= 100
+		trailingZeros := int64(1)
+		for nanos%10 == 0 && trailingZeros < 7 {
+			nanos /= 10
+			trailingZeros++
+		}
+		return nanos<<3 | trailingZeros
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -71,3 +71,21 @@ func BenchmarkzigzagDecodeeger(b *testing.B) {
 		zigzagDecode(uint64(i))
 	}
 }
+
+func TestFormatNanos(t *testing.T) {
+	testCases := []struct {
+		input    int64
+		expected int64
+	}{
+		{99, 0x0318},
+		{100, 0x09},
+		{1000, 0x0a},
+		{100000, 0x0c},
+	}
+	for _, v := range testCases {
+		output := formatNanos(v.input)
+		if output != v.expected {
+			t.Errorf("Input: %d. Expected %x got %x", v.input, v.expected, output)
+		}
+	}
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
 	"time"
 	// "encoding/json"
 	"math/rand"
-	"os"
 	"testing"
 )
 
@@ -25,13 +26,13 @@ func (b *bytesSizedReaderAt) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func TestWriter(t *testing.T) {
-
-	filename := "./testorc"
-
-	f, err := os.Create(filename)
+	f, err := ioutil.TempFile("", "testorc")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	filename := f.Name()
+	defer os.Remove(filename) // clean up
 	defer f.Close()
 
 	// schema, err := ParseSchema("struct<string1:string,int1:int,boolean1:boolean>")

--- a/writer_test.go
+++ b/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"time"
 	// "encoding/json"
 	"math/rand"
 	"os"
@@ -34,7 +35,7 @@ func TestWriter(t *testing.T) {
 	defer f.Close()
 
 	// schema, err := ParseSchema("struct<string1:string,int1:int,boolean1:boolean>")
-	schema, err := ParseSchema("struct<string1:string,int1:int,boolean1:boolean,double1:double,nested:struct<double2:double,nested:struct<int2:int>>>")
+	schema, err := ParseSchema("struct<string1:string,timestamp1:timestamp,int1:int,boolean1:boolean,double1:double,nested:struct<double2:double,nested:struct<int2:int>>>")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,10 +45,13 @@ func TestWriter(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	now := time.Unix(1478123411, 99).UTC()
+	timeIncrease := 5*time.Second + 10001*time.Nanosecond
 	length := 1000000
 	var intSum int64
 	for i := 0; i < length; i++ {
 		string1 := fmt.Sprintf("%x", rand.Int63n(1000))
+		timestamp1 := now.Add(time.Duration(i) * timeIncrease)
 		int1 := rand.Int63n(10000)
 		intSum += int1
 		boolean1 := int1 > 4444
@@ -58,7 +62,7 @@ func TestWriter(t *testing.T) {
 				rand.Int63n(10000),
 			},
 		}
-		err = w.Write(string1, int1, boolean1, double1, nested)
+		err = w.Write(string1, timestamp1, int1, boolean1, double1, nested)
 		// err = w.Write(string1, int1, boolean1)
 		// err = w.Write(string1)
 		if err != nil {
@@ -78,11 +82,27 @@ func TestWriter(t *testing.T) {
 	}
 
 	var compareIntSum int64
-	c := r.Select("int1")
+	var previousTimestamp time.Time
+	c := r.Select("int1", "timestamp1")
 	row := 0
 	for c.Stripes() {
 		for c.Next() {
 			compareIntSum += c.Row()[0].(int64)
+			timestamp, ok := c.Row()[1].(time.Time)
+			if !ok {
+				t.Fatalf("Row %d: Expected a time.Time but got %T", row, c.Row()[1])
+			}
+			if row == 0 {
+				if timestamp != now {
+					t.Fatalf("Row %d: Expected a timestamp %s got %s. Difference: %s", row, now, timestamp, now.Sub(timestamp))
+				}
+			} else {
+				d := timestamp.Sub(previousTimestamp)
+				if d != timeIncrease {
+					t.Fatalf("Row %d: Expected a time increase of %s but got %s", row, timeIncrease, d)
+				}
+			}
+			previousTimestamp = timestamp
 			row++
 		}
 	}


### PR DESCRIPTION
Add support for timestamps to the writer and fixes a bug in the handling of the nanoseconds part of the timestamp in the reader as per the insights available in this JIRA issue of the Apache ORC project:
https://issues.apache.org/jira/browse/ORC-163

I've validated the output of a generated file with the official C++ orc-contents tool, available in a docker image `mgilbir/orc-tools`.