### PR TITLE
Fix writer with null

### DIFF
--- a/treewriter.go
+++ b/treewriter.go
@@ -104,15 +104,19 @@ func (b *BaseTreeWriter) Write(i interface{}) error {
 		return nil
 	}
 	if i == nil {
-		// The stream has nulls, therefore, set hasNull to
-		// true and write the prior values to the stream.
+		// The stream has nulls, therefore, set hasNull to true
 		b.hasNull = true
-		for j := uint64(1); j < b.numValues; j++ {
-			err := b.present.WriteBool(true)
-			if err != nil {
-				return err
-			}
-		}
+
+		// FIXME: It's not according to the spec as it's should be optional
+		// FIXME: For some reason it doesn't work so until we figure out why
+		// FIXME: In this case explicit and redundant is better than buggy
+		// for j := uint64(0); j < b.numValues-1; j++ {
+		// 	err := b.present.WriteBool(true)
+		// 	if err != nil {
+		// 		return err
+		// 	}
+		// }
+
 		// If interface value is nil, then write false to isPresent stream.
 		return b.present.WriteBool(false)
 	}


### PR DESCRIPTION
There is a problem when writing columns with null.

The first commit illustrates the issue.
The second commit limits the number of rows returned based on the stripe metadata. Given that the present column has a 1-bit granularity level but the returned values are at the byte level, the number of returned items when nulls are involved is rounded up to the nearest byte multiple.
The third commit is not according to spec as it makes the present column explicit instead of optional. Somehow making it optional breaks the reader and the resulting files are corrupt and not readable by the official tools with multiple errors such as:

`Caught exception: bad read in nextBuffer`
`Caught exception: bad read in RleDecoderV2::readByte`

This would make me think that there are additional issues in the RLE encoding, but until we have time to figure that out, always writing explicitly the present column generates valid files that can be properly read both by this library and the official tools.