### PR TITLE
treewriter: only return row indexes for primitive column types

### DIFF
--- a/treewriter.go
+++ b/treewriter.go
@@ -174,6 +174,9 @@ func (b *BaseTreeWriter) Streams() []Stream {
 }
 
 func (b *BaseTreeWriter) RowIndex() *proto.RowIndex {
+	if !b.category.isPrimitive {
+		return nil
+	}
 	return &proto.RowIndex{
 		Entry: b.indexEntries,
 	}

--- a/writer.go
+++ b/writer.go
@@ -146,6 +146,10 @@ func NewWriter(w io.Writer, fns ...WriterConfigFunc) (*Writer, error) {
 	return writer, nil
 }
 
+func (w *Writer) Schema() *TypeDescription {
+	return w.schema
+}
+
 func (w *Writer) Write(values ...interface{}) error {
 	w.stripeRows++
 	w.totalRows++
@@ -324,8 +328,15 @@ func (w *Writer) writeStripe() error {
 	// Iterate through the TreeWriters and write their output
 	// to the underlying writer.
 	err := w.treeWriters.forEach(func(id int, t TreeWriter) error {
-		// First write the rowIndex for the column.
+
+		// Add to the running stripe statistics.
+		stripeStatistics.add(id, t.Statistics())
+
+		// Write rowIndex for the column.
 		rowIndex := t.RowIndex()
+		if rowIndex == nil {
+			return nil
+		}
 		byt, err := gproto.Marshal(rowIndex)
 		if err != nil {
 			return err
@@ -362,8 +373,6 @@ func (w *Writer) writeStripe() error {
 			Length: ptrUint64(uint64(l)),
 		}
 		streams = append(streams, streamInfo)
-		// Add to the running stripe statistics.
-		stripeStatistics.add(id, t.Statistics())
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Based on the first paragraph here, it appears row indexes should only be included for primitive columns: https://orc.apache.org/docs/spec-index.html