### PR TITLE
Fix zigzag benchmark naming.

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -60,13 +60,13 @@ func TestZigZagDecode(t *testing.T) {
 	}
 }
 
-func BenchmarkzigzagEncodeeger(b *testing.B) {
+func BenchmarkZigZagEncode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		zigzagEncode(int64(i))
 	}
 }
 
-func BenchmarkzigzagDecodeeger(b *testing.B) {
+func BenchmarkZigZagDecode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		zigzagDecode(uint64(i))
 	}


### PR DESCRIPTION
go test requires the letter after the "Benchmark" prefix to not be lowercase in order to recognize a function as a a benchmark.