### PR TITLE
Add NumStripes() and SelectStripe() to Reader and Cursor

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -44,6 +44,17 @@ func (c *Cursor) Select(fields ...string) *Cursor {
 	return c
 }
 
+// SelectStripe retrieves the stream information for the specified stripe.
+func (c *Cursor) SelectStripe(n int) error {
+	stripe, err := c.Reader.getStripe(n, c.included...)
+	if err != nil {
+		return err
+	}
+	c.Stripe = stripe
+	c.stripeOffset = n
+	return c.prepareStreamReaders()
+}
+
 // prepareStreamReaders prepares TreeReaders for each of the columns
 // that will be read.
 func (c *Cursor) prepareStreamReaders() error {
@@ -65,10 +76,11 @@ func (c *Cursor) prepareNextStripe() error {
 	// and creating the required readers for each of the
 	// required columns.
 	var err error
-	c.Stripe, err = c.Reader.getStripe(c.stripeOffset, c.included...)
+	stripe, err := c.Reader.getStripe(c.stripeOffset, c.included...)
 	if err != nil {
 		return err
 	}
+	c.Stripe = stripe
 	c.stripeOffset++ // Increment in order to fetch the next stripe.
 	return c.prepareStreamReaders()
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/scritchley/orc/proto"
 )
 
@@ -93,7 +94,6 @@ func TestCursorResets(t *testing.T) {
 
 }
 
-
 func TestCursorSelectError(t *testing.T) {
 
 	r, err := Open("./examples/demo-11-zlib.orc")
@@ -104,16 +104,16 @@ func TestCursorSelectError(t *testing.T) {
 
 	// Try to select a column that doesn't exist.
 	c := r.Select("notfound")
-	
+
 	var hasNext bool
 	for c.Next() {
 		hasNext = true
 	}
-	
+
 	if hasNext {
 		t.Errorf("Next returned true, expected false")
 	}
-	
+
 	err = c.Err()
 	if err == nil {
 		t.Errorf("Expected error")
@@ -121,6 +121,52 @@ func TestCursorSelectError(t *testing.T) {
 	if err.Error() != "no field with name: notfound" {
 		t.Errorf("Unexpected error: %s", err.Error())
 	}
-	
-	
+
+}
+
+func TestCursorSelectStripe(t *testing.T) {
+	r, err := Open("./examples/demo-11-none.orc")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	expectedStripes := 385
+
+	numStripes, err := r.NumStripes()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if numStripes != expectedStripes {
+		t.Fatalf("Expected %d stripes, got %d", expectedStripes, numStripes)
+	}
+
+	cols := r.Schema().Columns()
+	c := r.Select(cols...)
+
+	err = c.SelectStripe(numStripes - 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	var row []interface{}
+	for c.Next() {
+		row = c.Row()
+	}
+
+	expectedLastRow := []interface{}{
+		int64(1920800),
+		"F",
+		"U",
+		"Unknown",
+		int64(10000),
+		"Unknown",
+		int64(6),
+		int64(6),
+		int64(6),
+	}
+
+	if !cmp.Equal(expectedLastRow, row) {
+		t.Fatalf("Expected %v, got %v", expectedLastRow, row)
+	}
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/scritchley/orc/proto"
 )
 
@@ -166,7 +165,13 @@ func TestCursorSelectStripe(t *testing.T) {
 		int64(6),
 	}
 
-	if !cmp.Equal(expectedLastRow, row) {
-		t.Fatalf("Expected %v, got %v", expectedLastRow, row)
+	if len(row) != len(expectedLastRow) {
+		t.Fatalf("Expected %d elements, got %d", len(expectedLastRow), len(row))
+	}
+
+	for idx, e := range expectedLastRow {
+		if e != row[idx] {
+			t.Fatalf("Expected %v, got %v", e, row[idx])
+		}
 	}
 }

--- a/reader.go
+++ b/reader.go
@@ -341,6 +341,15 @@ func (r *Reader) NumRows() int {
 	return int(r.footer.GetNumberOfRows())
 }
 
+func (r *Reader) NumStripes() (int, error) {
+	stripes, err := r.getStripes()
+	if err != nil {
+		return 0, err
+	}
+
+	return len(stripes), nil
+}
+
 type Stripe struct {
 	included []int
 	*proto.StripeInformation

--- a/reader_test.go
+++ b/reader_test.go
@@ -37,3 +37,23 @@ func TestReadNullAtEnd(t *testing.T) {
 		}
 	}
 }
+
+func TestNumStripes(t *testing.T) {
+	expectedStripes := 385
+
+	r, err := Open("examples/demo-11-none.orc")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	defer r.Close()
+
+	n, err := r.NumStripes()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if n != expectedStripes {
+		t.Fatalf("Expected %d stripes, got %d", expectedStripes, n)
+	}
+}


### PR DESCRIPTION
- this will add `Reader.NumStripes()`, which will simply examine the footer and return the number of stripes in the file
- `Cursor.SelectStripe(n)` prepares the n-th stripe in the file for reading, upon which `Cursor.Next()` and `Cursor.Row()` can be called as normal
- this will allow users to read only select stripes in question as needed