### PR TITLE
Add default writer timezone

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -19,6 +19,8 @@ var (
 	DefaultStripeTargetSize int64 = 200 * 1024 * 1024
 	// DefaultStripeTargetRowCount is the number of rows over which a stripe should be written to the underlying file.
 	DefaultStripeTargetRowCount int64 = 1024 * 1024
+	// DefaultStripeWriterTimezone is the timezone that writer adds into the stripe footer.
+	DefaultStripeWriterTimezone string = "GMT"
 	// DefaultCompressionChunkSize is the default size of compression chunks within each stream.
 	DefaultCompressionChunkSize uint64 = 256 * 1024
 	// DefaultRowIndexStride is the default number of rows between indexes
@@ -415,8 +417,9 @@ func (w *Writer) writeStripe() error {
 
 	// Create a stripe footer and write it to the underlying writer.
 	stripeFooter := &proto.StripeFooter{
-		Streams: streams,
-		Columns: w.treeWriters.encodings(),
+		Streams:        streams,
+		Columns:        w.treeWriters.encodings(),
+		WriterTimezone: &DefaultStripeWriterTimezone,
 	}
 
 	byt, err := gproto.Marshal(stripeFooter)


### PR DESCRIPTION
This PR adds a default writer timezone into the stripe when writing ORC files. 

Since the original ORC writer doesn't write with explicit time zone, at read time, since we need to convert the timestamp into UTC, the library needs to assume it was written using local time zone and then gets the local time zone info from file "/etc/localtime" on the machine before doing the conversion to UTC. 

We have encountered this issue when re-ingesting ORC files generated into BigQuery. For the BQ servers currently, they all have PST as the local time zone and it outputs wrong time during Daylight Saving Time.

In order to fix such issues, this PR adds an explicit writer timezone set to `GMT`, instead of leaving it omitted, so the timestamp will be always converted to a same UTC value regardless of where the reader runs (i.e., local timezone of the machine where the reader program runs won't matter). 

Curiously, this also was the issue in the C++ writer: 
 * https://issues.apache.org/jira/browse/ORC-320
 * https://issues.apache.org/jira/browse/ORC-322
 * https://github.com/apache/orc/blob/028261ad6e26d8ae9f9483c8aeb76a85c7f1168b/c%2B%2B/src/Writer.cc#L444
