### PR TITLE
Fix double Next for base tree reader in float tree reader

### DIFF
--- a/treereader.go
+++ b/treereader.go
@@ -694,10 +694,7 @@ func (r *FloatTreeReader) Next() bool {
 	if !r.BaseTreeReader.Next() {
 		return false
 	}
-	if !r.BaseTreeReader.IsPresent() {
-		return true
-	}
-	return r.BaseTreeReader.Next()
+	return true
 }
 
 func (r *FloatTreeReader) Float() Float {


### PR DESCRIPTION
This should fix #66 
@scritchley kindly help review thanks.
I think IsPresent is not necessary to check in Next, as in Value there is a IsPresent check as well. wdyt?